### PR TITLE
feat: Add email service

### DIFF
--- a/.env.docker
+++ b/.env.docker
@@ -13,3 +13,8 @@ ADDR=0.0.0.0
 SSL_MODE=disable
 JWT_SECRET_KEY=generate_random_value_for_this
 FILE_SIZE_LIMIT=209715200
+
+SMTPHost=smtp.gmail.com
+SMTPPort=587
+SMTPUser=
+SMTPPAssword=

--- a/.env.docker
+++ b/.env.docker
@@ -17,4 +17,4 @@ FILE_SIZE_LIMIT=209715200
 SMTPHost=smtp.gmail.com
 SMTPPort=587
 SMTPUser=
-SMTPPAssword=
+SMTPPassword=

--- a/config/config.go
+++ b/config/config.go
@@ -40,7 +40,7 @@ type Config struct {
 
 	SMTPHost     string
 	SMTPPort     string
-	SMTPPAssword string
+	SMTPPassword string
 	SMTPUser     string
 }
 
@@ -111,7 +111,7 @@ func LoadConfig(envFile string) error {
 
 		SMTPHost:     os.Getenv("SMTPHost"),
 		SMTPPort:     os.Getenv("SMTPPort"),
-		SMTPPAssword: os.Getenv("SMTPPAssword"),
+		SMTPPassword: os.Getenv("SMTPPassword"),
 		SMTPUser:     os.Getenv("SMTPUser"),
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -37,6 +37,11 @@ type Config struct {
 	JWTSecretKey           string
 	FileSizeLimit          string
 	Debug                  bool
+
+	SMTPHost     string
+	SMTPPort     string
+	SMTPPAssword string
+	SMTPUser     string
 }
 
 var AppConfig *Config
@@ -103,6 +108,11 @@ func LoadConfig(envFile string) error {
 		JWTSecretKey:           os.Getenv("JWT_SECRET_KEY"),
 		FileSizeLimit:          os.Getenv("FILE_SIZE_LIMIT"),
 		Debug:                  debug,
+
+		SMTPHost:     os.Getenv("SMTPHost"),
+		SMTPPort:     os.Getenv("SMTPPort"),
+		SMTPPAssword: os.Getenv("SMTPPAssword"),
+		SMTPUser:     os.Getenv("SMTPUser"),
 	}
 
 	if config.JWTSecretKey == "" {

--- a/services/smtp.go
+++ b/services/smtp.go
@@ -1,0 +1,28 @@
+package services
+
+import (
+	"net/smtp"
+	"video-streaming-server/config"
+	"video-streaming-server/shared/logger"
+)
+
+func SendEmail(to []string, body string) error {
+	user := config.AppConfig.SMTPUser
+	password := config.AppConfig.SMTPPAssword
+
+	host := config.AppConfig.SMTPHost
+	port := config.AppConfig.SMTPPort
+	addr := host + ":" + port
+
+	auth := smtp.PlainAuth("", user, password, host)
+
+	err := smtp.SendMail(addr, auth, user, to, []byte(body))
+
+	if err != nil {
+		logger.Log.Error(err.Error())
+
+		return err
+	}
+
+	return nil
+}

--- a/services/smtp.go
+++ b/services/smtp.go
@@ -8,14 +8,22 @@ import (
 	"video-streaming-server/shared/logger"
 )
 
-//SendEmail is a wrapper over smtp.SendEmail.
+type message struct {
+	sender     string
+	recipients []string
+	isHTML     bool
+	subject    string
+	body       string
+}
+
+// SendEmail is a wrapper over smtp.SendEmail.
 //
-//This function consumes information like host address, username and password from the config.
+// This function consumes information like host address, username and password from the config.
 //
-//Recipients is an array of string which is joined using comma (,) 
-//separator in the function, creating a comma separated string
-func SendEmail(recipients []string, sender string, subject string, body string) error {
-	if len(recipients) == 0 {
+// Recipients is an array of string which is joined using comma (,)
+// separator in the function, creating a comma separated string
+func SendEmail(msg *message) error {
+	if len(msg.recipients) == 0 {
 		return errors.New("Recipients should not be emtpy")
 	}
 
@@ -28,11 +36,17 @@ func SendEmail(recipients []string, sender string, subject string, body string) 
 
 	auth := smtp.PlainAuth("", user, password, host)
 
-	msg := "From: " + sender + "\r\n" +
-	"To: " + strings.Join(recipients, ",") + "\r\n" +
-	"Subject: " + subject + "\r\n" + body
+	message := "From: " + msg.sender + "\r\n" +
+		"To: " + strings.Join(msg.recipients, ",") + "\r\n" +
+		"Subject: " + msg.subject + "\r\n"
 
-	err := smtp.SendMail(addr, auth, user, recipients, []byte(msg))
+	if msg.isHTML {
+		message += "MIME-version: 1.0;\nContent-Type: text/html; charset=\"UTF-8\";\n\n"
+	}
+
+	message += msg.body
+
+	err := smtp.SendMail(addr, auth, user, msg.recipients, []byte(message))
 
 	if err != nil {
 		logger.Log.Error(err.Error())

--- a/services/smtp.go
+++ b/services/smtp.go
@@ -1,14 +1,26 @@
 package services
 
 import (
+	"errors"
 	"net/smtp"
+	"strings"
 	"video-streaming-server/config"
 	"video-streaming-server/shared/logger"
 )
 
-func SendEmail(to []string, body string) error {
+//SendEmail is a wrapper over smtp.SendEmail.
+//
+//This function consumes information like host address, username and password from the config.
+//
+//Recipients is an array of string which is joined using comma (,) 
+//separator in the function, creating a comma separated string
+func SendEmail(recipients []string, sender string, subject string, body string) error {
+	if len(recipients) == 0 {
+		return errors.New("Recipients should not be emtpy")
+	}
+
 	user := config.AppConfig.SMTPUser
-	password := config.AppConfig.SMTPPAssword
+	password := config.AppConfig.SMTPPassword
 
 	host := config.AppConfig.SMTPHost
 	port := config.AppConfig.SMTPPort
@@ -16,7 +28,11 @@ func SendEmail(to []string, body string) error {
 
 	auth := smtp.PlainAuth("", user, password, host)
 
-	err := smtp.SendMail(addr, auth, user, to, []byte(body))
+	msg := "From: " + sender + "\r\n" +
+	"To: " + strings.Join(recipients, ",") + "\r\n" +
+	"Subject: " + subject + "\r\n" + body
+
+	err := smtp.SendMail(addr, auth, user, recipients, []byte(msg))
 
 	if err != nil {
 		logger.Log.Error(err.Error())


### PR DESCRIPTION
## Description
This PR adds an email service that can be used to send emails to user or multiple users. Closes #81 

## Summary of changes
- Add smtp service
- Add function to send email to user
- Add config for smtp service

## Summary by Sourcery

Add a configurable SMTP email service with a SendEmail function to deliver messages and log errors

New Features:
- Introduce SMTP-based email service for sending emails to one or more recipients

Enhancements:
- Load SMTP configuration (host, port, user, password) from environment variables